### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main", "develop", "*" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Matumo/ts-simple-logger/security/code-scanning/2](https://github.com/Matumo/ts-simple-logger/security/code-scanning/2)

To fix the problem, explicitly define `permissions` so the `GITHUB_TOKEN` is restricted to the minimum required scopes. Since this workflow only checks out code, runs npm commands, and uploads artifacts, it only needs read access to repository contents. The cleanest fix without altering existing behavior is to add a root-level `permissions` block just under the workflow name, applying to all jobs.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

after `name: CI` and before the `on:` section. This sets `contents: read` for the entire workflow. No additional imports, actions, or steps are required, and all existing functionality (checkout, build, test, artifact upload) will continue to work.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
